### PR TITLE
layout.qtpl: Make sure background is white

### DIFF
--- a/template/layout.qtpl
+++ b/template/layout.qtpl
@@ -14,6 +14,7 @@ The main layout function.
               max-width: 650px;
               line-height: 1.6;
               font-size: 18px;
+              background: #fff;
               color: #444;
               padding: 0 10px;
             }


### PR DESCRIPTION
Makes it readable whem WebKitGTK 2.25+ is used with a dark GTK theme (thanks to them for triggering something know to be broken on the web for ages).